### PR TITLE
Fix: Bug que hacia que el segundo parametro no se guarde en History

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -42,6 +42,7 @@ export async function createHistoryEntry({ firstArg, secondArg, operationName, r
 
     return History.create({
         firstArg,
+        secondArg, //Arreglar el bug que hace que no se guarde el segundo parametro en la tabla History y hacer el test correspondiente
         result,
         OperationId: operation.id
     })

--- a/test/models.test.js
+++ b/test/models.test.js
@@ -24,6 +24,8 @@ describe("History", () => {
 
         expect(histories.length).toEqual(1)
         expect(histories[0].firstArg).toEqual(2)
+        //Arreglar el bug que hace que no se guarde el segundo parametro en la tabla History y hacer el test correspondiente
+        expect(histories[0].secondArg).toEqual(2)
         expect(histories[0].result).toEqual(0)
         expect(histories[0].Operation.name).toEqual("SUB")
     })


### PR DESCRIPTION
Agregué una línea tanto en ./test/models.test.js como en ./src/models.js. Corrí los test y todo anda joya pero prueben por las dudas. Si les tira error de sequelize tiren _npm install sequelize_