### PR TITLE
Fix: Error que llamaba funciones nativas en los tests

### DIFF
--- a/src/controllers.js
+++ b/src/controllers.js
@@ -77,7 +77,7 @@ router.get("/pow/:a", async function (req, res) {
     }
 });
 
-router.get("/history", async function (req, res) {
+router.get("/history/deleted", async function (req, res) {
     await deleteHistory();
     return res.send({ message: "history is deleted"});
 });

--- a/src/models.js
+++ b/src/models.js
@@ -68,11 +68,7 @@ export async function deleteHistory (){
 }
 
 export async function getFullHistory() {
-    const histories = await History.findAll({
-        include: [Operation]
-    });
-    
-    return histories;
+    return History.findAll();
 }
 
 //Hacer un endpoint para obtener una entrada del historial por id, con el test correspondiente

--- a/test/models.test.js
+++ b/test/models.test.js
@@ -3,7 +3,9 @@ const {
     createHistoryEntry,
     History,
     Operation,
-    buscarPorID
+    buscarPorID,
+    deleteHistory,
+    getFullHistory
 } = require('../src/models.js')
 
 beforeEach(async () => {
@@ -36,7 +38,7 @@ describe("History", () => {
 })
 
 describe("History", () => {
-    test("Debería devolver todo el historial", async() => {
+    test("Debería devolver un mensaje de historial borrado", async() => {
         await createHistoryEntry({
             firstArg: 10,
             secondArg: 5,
@@ -49,9 +51,10 @@ describe("History", () => {
             result: 2,
             operationName: "SUB"
         });
-        const histories = await History.count();
-        const histories_deleted = await History.destroy({ where: {}});
-        expect(histories_deleted).toEqual(histories);
+        const histories_deleted = await deleteHistory();
+        const histories = await getFullHistory();
+        expect(histories_deleted).toEqual(2);
+        expect(histories.length).toEqual(0);
     });
 });
 
@@ -71,7 +74,7 @@ describe("History", () => {
             operationName: "SUB"
         });
 
-        const histories = await History.findAll();
+        const histories = await getFullHistory();
         expect(histories.length).toEqual(2);
         expect(histories[0].firstArg).toEqual(20);
         expect(histories[0].secondArg).toEqual(9);
@@ -98,7 +101,7 @@ describe("History", () => {
             });
         
         //Lo que se pretende en el test es que devuelva la segunda entrada, no la primera
-        const histories = await History.findAll();
+        const histories = await getFullHistory();
         const historyId = histories[1].id;
         const entrada = await buscarPorID(historyId);
         expect(entrada.id).toEqual(historyId);


### PR DESCRIPTION
Se solucionaron los errores que llamaban a las funciones nativas de sequelize.
Se modificó el código de getFullHistory.
Se modificó el nombre de un endpoint que se llamaba igual a otro.